### PR TITLE
feat(server): add github oauth compat routes

### DIFF
--- a/.yarn/versions/865ccfd4.yml
+++ b/.yarn/versions/865ccfd4.yml
@@ -1,0 +1,2 @@
+releases:
+  "@aoi-js/server": patch

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -17,6 +17,7 @@
     "@aoi-js/common": "workspace:^",
     "@aws-sdk/client-s3": "^3.385.0",
     "@aws-sdk/s3-request-presigner": "^3.385.0",
+    "@fastify/formbody": "^7.4.0",
     "@fastify/jwt": "^7.2.0",
     "@fastify/sensible": "^5.2.0",
     "@fastify/type-provider-typebox": "^3.3.0",

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -113,6 +113,10 @@ export const apiRoutes = defineRoutes(async (s) => {
     req._container = createInjectionContainer()
 
     if (req.headers.authorization) {
+      // Allow type token which is a alias of bearer
+      if (/^Token\s/i.test(req.headers.authorization)) {
+        req.headers.authorization = req.headers.authorization.replace(/^Token\s/i, 'Bearer ')
+      }
       await req.jwtVerify()
 
       // Only allow tagged routes

--- a/apps/server/src/routes/oauth/github-compat.ts
+++ b/apps/server/src/routes/oauth/github-compat.ts
@@ -14,7 +14,7 @@ export const oauthGithubCompatRoutes = defineRoutes(async (s) => {
         }
       }
     },
-    () => {}
+    () => ({})
   )
 
   s.get(
@@ -128,7 +128,7 @@ export const oauthGithubCompatRoutes = defineRoutes(async (s) => {
             Type.Object({
               name: Type.String(),
               slug: Type.String(),
-              org: Type.Object({
+              organization: Type.Object({
                 login: Type.String()
               })
             })
@@ -169,7 +169,7 @@ export const oauthGithubCompatRoutes = defineRoutes(async (s) => {
       return groups.map((group) => ({
         name: group.profile.name,
         slug: group._id,
-        org: { login: group.org.profile.name }
+        organization: { login: group.org.profile.name }
       }))
     }
   )

--- a/apps/server/src/routes/oauth/github-compat.ts
+++ b/apps/server/src/routes/oauth/github-compat.ts
@@ -1,0 +1,176 @@
+import { Type } from '@sinclair/typebox'
+import { defineRoutes, swaggerTagMerger } from '../common/index.js'
+import { orgMemberships, users } from '../../index.js'
+
+export const oauthGithubCompatRoutes = defineRoutes(async (s) => {
+  s.addHook('onRoute', swaggerTagMerger('github-compat'))
+
+  s.get(
+    '/',
+    {
+      schema: {
+        response: {
+          200: Type.Object({})
+        }
+      }
+    },
+    () => {}
+  )
+
+  s.get(
+    '/user',
+    {
+      schema: {
+        response: {
+          200: Type.Object({
+            login: Type.String(),
+            email: Type.String()
+          })
+        }
+      }
+    },
+    async (req, rep) => {
+      const user = await users.findOne(
+        { _id: req.user.userId },
+        { projection: { 'profile.name': 1, 'profile.email': 1 } }
+      )
+      if (!user) return rep.notFound()
+      return {
+        login: user.profile.name,
+        email: user.profile.email
+      }
+    }
+  )
+
+  s.get(
+    '/user/emails',
+    {
+      schema: {
+        response: {
+          200: Type.Array(
+            Type.Object({
+              email: Type.String(),
+              primary: Type.Boolean(),
+              verified: Type.Boolean()
+            })
+          )
+        }
+      }
+    },
+    async (req, rep) => {
+      const user = await users.findOne(
+        { _id: req.user.userId },
+        { projection: { 'profile.email': 1, 'authSources.mail': 1 } }
+      )
+      if (!user) return rep.notFound()
+      return [
+        {
+          email: user.profile.email,
+          primary: true,
+          verified: !!user.authSources.mail
+        }
+      ]
+    }
+  )
+
+  s.get(
+    '/user/orgs',
+    {
+      schema: {
+        querystring: Type.Object({
+          per_page: Type.Integer({ maximum: 100, minimum: 100 }),
+          page: Type.Integer()
+        }),
+        response: {
+          200: Type.Array(
+            Type.Object({
+              login: Type.String()
+            })
+          )
+        }
+      }
+    },
+    async (req) => {
+      const skip = (req.query.page - 1) * req.query.per_page
+      const limit = req.query.per_page
+      const orgs = await orgMemberships
+        .aggregate([
+          { $match: { userId: req.user.userId } },
+          { $skip: skip },
+          { $limit: limit },
+          {
+            $lookup: {
+              from: 'orgs',
+              localField: 'orgId',
+              foreignField: '_id',
+              as: 'org'
+            }
+          },
+          { $unwind: '$org' },
+          { $replaceRoot: { newRoot: '$org' } },
+          { $project: { 'profile.name': 1 } }
+        ])
+        .toArray()
+      return orgs.map((org) => ({ login: org.profile.name }))
+    }
+  )
+
+  s.get(
+    '/user/teams',
+    {
+      schema: {
+        querystring: Type.Object({
+          per_page: Type.Integer(),
+          page: Type.Integer()
+        }),
+        response: {
+          200: Type.Array(
+            Type.Object({
+              name: Type.String(),
+              slug: Type.String(),
+              org: Type.Object({
+                login: Type.String()
+              })
+            })
+          )
+        }
+      }
+    },
+    async (req) => {
+      const skip = (req.query.page - 1) * req.query.per_page
+      const limit = req.query.per_page
+      const groups = await orgMemberships
+        .aggregate([
+          { $match: { userId: req.user.userId } },
+          {
+            $lookup: {
+              from: 'groups',
+              localField: 'groups',
+              foreignField: '_id',
+              as: 'group'
+            }
+          },
+          { $unwind: '$group' },
+          { $replaceRoot: { newRoot: '$group' } },
+          { $skip: skip },
+          { $limit: limit },
+          {
+            $lookup: {
+              from: 'orgs',
+              localField: 'orgId',
+              foreignField: '_id',
+              as: 'org'
+            }
+          },
+          { $unwind: '$org' },
+          { $project: { _id: 1, 'profile.name': 1, 'org.profile.name': 1 } }
+        ])
+        .toArray()
+      return groups.map((group) => ({
+        name: group.profile.name,
+        slug: group._id,
+        org: { login: group.org.profile.name }
+      }))
+    }
+  )
+})

--- a/apps/server/src/routes/oauth/index.ts
+++ b/apps/server/src/routes/oauth/index.ts
@@ -3,8 +3,12 @@ import { defineRoutes } from '../common/index.js'
 import { UUID } from 'mongodb'
 import { IOrgMembership, IUser, apps, orgMemberships, users } from '../../db/index.js'
 import { SUserProfile } from '../../schemas/index.js'
+import { oauthGithubCompatRoutes } from './github-compat.js'
+import fastifyFormbody from '@fastify/formbody'
 
 export const oauthRoutes = defineRoutes(async (s) => {
+  s.register(fastifyFormbody)
+
   s.post(
     '/access_token',
     {
@@ -77,4 +81,6 @@ export const oauthRoutes = defineRoutes(async (s) => {
       return { access_token: token, token_type: 'bearer', user, membership }
     }
   )
+
+  s.register(oauthGithubCompatRoutes, { prefix: '/github_compat' })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,6 +287,7 @@ __metadata:
     "@aoi-js/common": "workspace:^"
     "@aws-sdk/client-s3": "npm:^3.385.0"
     "@aws-sdk/s3-request-presigner": "npm:^3.385.0"
+    "@fastify/formbody": "npm:^7.4.0"
     "@fastify/jwt": "npm:^7.2.0"
     "@fastify/sensible": "npm:^5.2.0"
     "@fastify/swagger": "npm:^8.12.1"
@@ -1725,6 +1726,16 @@ __metadata:
   dependencies:
     fast-json-stringify: "npm:^5.7.0"
   checksum: 10/9ad575907d44bbd371dbc23a51853fd349a459092340fe91c50317f92707961f2e6ca6c9d17707a8e4a087c635e09bce1166e082d54f191769a582339c94badd
+  languageName: node
+  linkType: hard
+
+"@fastify/formbody@npm:^7.4.0":
+  version: 7.4.0
+  resolution: "@fastify/formbody@npm:7.4.0"
+  dependencies:
+    fast-querystring: "npm:^1.0.0"
+    fastify-plugin: "npm:^4.0.0"
+  checksum: 10/976e2d33ec5dc447678a6b8572712fb956028b7c31feafb9e60eaf5311c8b5d710b975f72d4e9cdadc62e541db0887fc429656bb1797ad3078005b0f9cc8c39a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
By supporting github oauth compat routes, it's now able to use `oauth2-proxy` and other clients to login via AOI apps.

eg.

```
login_url="http://example.org/oauth/authorize"
redeem_url="http://example.org/api/oauth/access_token"
validate_url="http://example.org/api/oauth/github_compat/"
cookie_secret="secret..."
client_id="uuid"
client_secret="secret"
email_domains=["*"]
provider="github"
upstreams=["http://127.0.0.1:8000/"]
redirect_url="http://127.0.0.1:4180/oauth2/callback"
provider_display_name="AOI"
```